### PR TITLE
ssh nodes, and misc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ VOLUME /var/lib/munin
 VOLUME /var/log/munin
 
 ADD ./munin.conf /etc/munin/munin.conf
-AdD ./nginx.conf /etc/nginx/nginx.conf
+ADD ./nginx.conf /etc/nginx/nginx.conf
 ADD ./nginx-munin /etc/nginx/sites-enabled/munin
 ADD ./start-munin.sh /munin
 ADD ./munin-graph-logging.patch /usr/share/munin

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The port is always optional, default is 4949
 
 * `NODES` format: `name1:ip1[:port1] name2:ip2[:port2] …`
 * `SNMP_NODES` format: `name1:ip1[:port1]` …
+* `SSH_NODES` format: `name1:ip1[:port1]` …
 
 ## Port
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -26,5 +26,3 @@ http {
 	include /etc/nginx/conf.d/*.conf;
 	include /etc/nginx/sites-enabled/*;
 }
-
-

--- a/start-munin.sh
+++ b/start-munin.sh
@@ -49,7 +49,7 @@ fi
 
 # generate the Munin auth username/password file
 if [ ! -f /etc/munin/htpasswd.users ]; then
-  uc = 0
+  uc=0
   IFS=' ' read -ra ARR_USERS <<< "$MUNIN_USERS"
   IFS=' ' read -ra ARR_PASSWORDS <<< "$MUNIN_PASSWORDS"
   for u in "${ARR_USERS[@]}"; do
@@ -67,7 +67,7 @@ do
   if [ ${#PORT} -eq 0 ]; then
       PORT=4949
   fi
-  if ! grep -q $HOST /etc/munin/munin.conf ; then
+  if ! grep -q "'^$HOST$'" /etc/munin/munin.conf ; then
     cat << EOF >> /etc/munin/munin.conf
 [$NAME]
     address $HOST
@@ -75,6 +75,7 @@ do
     port $PORT
 
 EOF
+    echo "Added node '$NAME' '$HOST'"
     fi
 done
 
@@ -87,7 +88,7 @@ do
   if [ ${#PORT} -eq 0 ]; then
       PORT=4949
   fi
-  if ! grep -q $HOST /etc/munin/munin.conf ; then
+  if ! grep -q "'^$HOST$'" /etc/munin/munin.conf ; then
     cat << EOF >> /etc/munin/munin.conf
 [$NAME]
     address $HOST
@@ -95,6 +96,7 @@ do
     port $PORT
 
 EOF
+    echo "Added SNMP node '$NAME' '$HOST'"
     fi
 done
 
@@ -119,16 +121,20 @@ fi
 /usr/sbin/rsyslogd
 # start cron
 /usr/sbin/cron
+# Issue: 'NUMBER OF HARD LINKS > 1' prevents cron exec in container
+# https://github.com/phusion/baseimage-docker/issues/198
+touch /etc/crontab /etc/cron.d/*
 # start local munin-node
 /usr/sbin/munin-node
 echo "Using the following munin nodes:"
 echo $NODES
+echo "(snmp) $SNMP_NODES"
 # start spawn-cgi to enable CGI interface with munin (dynamix graph generation)
 spawn-fcgi -s /var/run/munin/fcgi-graph.sock -U munin -u munin -g munin /usr/lib/munin/cgi/munin-cgi-graph
 # start nginx
 /usr/sbin/nginx
 # show logs
-echo "Tailing /var/log/syslog..."
+echo "Tailing syslog and munin-update log..."
 tail -F /var/log/syslog /var/log/munin/munin-update.log & pid=$!
 echo "tail -F running in $pid"
 

--- a/start-munin.sh
+++ b/start-munin.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 NODES=${NODES:-}
 SNMP_NODES=${SNMP_NODES:-}
+SSH_NODES=${SSH_NODES:-}
 MUNIN_USERS=${MUNIN_USERS:-${MUNIN_USER:-user}}
 MUNIN_PASSWORDS=${MUNIN_PASSWORDS:-${MUNIN_PASSWORD:-password}}
 MAIL_CONF_PATH='/var/lib/munin/.mailrc'
@@ -100,6 +101,26 @@ EOF
     fi
 done
 
+for SSH_NODE in $SSH_NODES
+do
+  NAME=`echo $SSH_NODE | cut -d ":" -f1`
+  HOST=`echo $SSH_NODE | cut -d ":" -f2`
+  PORT=`echo $SSH_NODE | cut -d ":" -f3`
+  if [ ${#PORT} -eq 0 ]; then
+      PORT=4949
+  fi
+  if ! grep -q "'^$HOST$'" /etc/munin/munin.conf ; then
+    cat << EOF >> /etc/munin/munin.conf
+[$NAME]
+    address ssh://$HOST/usr/bin/nc localhost 4949
+    use_node_name yes
+    port $PORT
+
+EOF
+    echo "Added SSH node '$NAME' '$HOST'"
+    fi
+done
+
 [ -d /var/cache/munin/www ] || mkdir /var/cache/munin/www
 # placeholder html to prevent permission error
 if [ ! -e /var/cache/munin/www/index.html ]; then
@@ -128,6 +149,7 @@ touch /etc/crontab /etc/cron.d/*
 /usr/sbin/munin-node
 echo "Using the following munin nodes:"
 echo $NODES
+echo "(ssh) $SSH_NODES"
 echo "(snmp) $SNMP_NODES"
 # start spawn-cgi to enable CGI interface with munin (dynamix graph generation)
 spawn-fcgi -s /var/run/munin/fcgi-graph.sock -U munin -u munin -g munin /usr/lib/munin/cgi/munin-cgi-graph


### PR DESCRIPTION
First commit add some verboseness, minor typos fixed, and updates greps. I had some minor issues with the node update script grep including partial name matches.

Second commit adds support for SSH_NODES, which is the main point for the PR.

The image over at hub is quite old unfortenately, over a year [1]. I'm using my own autobuild triggered by my fork and ubuntu for now. [2]


[1] https://hub.docker.com/r/scalingo/munin-server/
[2] https://hub.docker.com/r/bvberkum/munin-server/