### PR TITLE
Ubuntu Focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:14.04
+FROM ubuntu:20.04
 
 MAINTAINER Leo Unbekandt <leo@scalingo.com>
 
 RUN adduser --system --home /var/lib/munin --shell /bin/false --uid 1103 --group munin
 
 RUN apt-get update -qq && RUNLEVEL=1 DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y -qq cron munin munin-node nginx wget heirloom-mailx patch spawn-fcgi libcgi-fast-perl
+    apt-get install -y -qq cron munin munin-node nginx wget bsd-mailx patch spawn-fcgi libcgi-fast-perl telnet
 RUN rm /etc/nginx/sites-enabled/default && mkdir -p /var/cache/munin/www && chown munin:munin /var/cache/munin/www && mkdir -p /var/run/munin && chown -R munin:munin /var/run/munin
 
 VOLUME /var/lib/munin

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ docker run -d \
   munin-server
 ```
 
+A simple `run-image` example is provided which assumes `munin.conf` contains environment variable values, or copied from a local Munin server instance.
+
 You can now reach your munin-server on port 8080 of your host. It will display at the first run:
 
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ For a bit of persistency
 
 ```
 docker build -t munin-server .
+
+# docker build --network=host -t munin-server .
+
 docker run -d \
   -p 8080:8080 \
   -v /var/log/munin:/var/log/munin \

--- a/run-image
+++ b/run-image
@@ -1,0 +1,8 @@
+docker run -d --name=munin --net=host \
+  -v /var/log/munin:/var/log/munin \
+  -v /var/lib/munin:/var/lib/munin \
+  -v /var/run/munin:/var/run/munin \
+  -v /var/cache/munin:/var/cache/munin \
+  -e MUNIN_USERS='munin' \
+  -e MUNIN_PASSWORDS='munin' \
+  munin-server


### PR DESCRIPTION
- Base on Ubuntu 20.04
- Replace heirloom-mail with bsd-mailx as heirloom is not in base 20.04 apt repos
- Add example for using local munin.conf